### PR TITLE
fix: 🐛 card display

### DIFF
--- a/libs/ui/src/lib/containers/Card/Card.style.ts
+++ b/libs/ui/src/lib/containers/Card/Card.style.ts
@@ -39,6 +39,7 @@ export const Card = styled.article`
   background: #fff;
   border-radius: ${pxToRem(4)};
   box-sizing: border-box;
+  display: inline-block;
   flex: 1 1 ${pxToRem(235)};
   margin: ${pxToRem(12)};
 


### PR DESCRIPTION


**Esse PR é do tipo:**

- [ ] feature
- [x] bug
- [ ] chore

Adicionei um `display: inline-block` no Card para ele pegar as margens dos componentes internos.


|    Layout ANTES da alteração    |    Layout DEPOIS da alteração    |
| :-----------------------------: | :------------------------------: |
| ![image](https://user-images.githubusercontent.com/5813101/89449408-64a21500-d72f-11ea-9052-685170cd2764.png) | ![image](https://user-images.githubusercontent.com/5813101/89449519-93b88680-d72f-11ea-92f3-521f78b75573.png) |

