### PR TITLE
fix: 🐛 Toast position

### DIFF
--- a/libs/ui/src/lib/notification/Toast/Toast.style.ts
+++ b/libs/ui/src/lib/notification/Toast/Toast.style.ts
@@ -71,7 +71,7 @@ const toastTypes = {
 export const ToastContainer = styled.div`
   overflow: hidden;
   padding: 16px;
-  position: absolute;
+  position: fixed;
   right: 0;
   top: 0;
   z-index: 100;


### PR DESCRIPTION

**Esse PR é do tipo:**

- [ ] feature
- [x] bug
- [ ] chore

**O que estava acontecendo? Qual era o problema? Qual a necessidade?**

O ideal é que o toast ficasse sempre visível na tela e, com o posicionamento anterior do container, ele ficava no topo da tela, mas não necessariamente sempre visível.

