### PR TITLE
fix: 🐛 adjust checkboxes hover color

### DIFF
--- a/libs/ui/src/lib/forms/Checkbox/Checkbox.style.ts
+++ b/libs/ui/src/lib/forms/Checkbox/Checkbox.style.ts
@@ -20,13 +20,19 @@ export const FormControlLabel = styled(MuiFormControlLabel)`
     };
 
     return css`
-      .MuiCheckbox-root {
-        color: ${colors[variant] || colors.simple};
-        &.Mui-checked {
-          color: ${theme?.colors?.brand?.secondary?.default};
-        }
-        &.Mui-disabled {
-          color: ${theme?.colors?.neutral?.light};
+      && {
+        .MuiCheckbox-root {
+          color: ${colors[variant] || colors.simple};
+          &.Mui-checked {
+            color: ${theme?.colors?.brand?.secondary?.default};
+          }
+          &.Mui-disabled {
+            color: ${theme?.colors?.neutral?.light};
+          }
+
+          &:hover {
+            background-color: ${theme?.colors?.brand?.secondary?.lightest};
+          }
         }
       }
 

--- a/libs/ui/src/lib/forms/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/libs/ui/src/lib/forms/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Checkbox Component renders correctly 1`] = `
 <label
-  className="MuiFormControlLabel-root css-1l8qi0x"
+  className="MuiFormControlLabel-root css-vpnmcr"
   variant="simple"
 >
   <span

--- a/libs/ui/src/lib/navigation/Accordion/Accordion.style.ts
+++ b/libs/ui/src/lib/navigation/Accordion/Accordion.style.ts
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-import MuiExpansionPanel from '@material-ui/core/ExpansionPanel';
-import MuiExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import MuiExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import MuiAccordion from '@material-ui/core/Accordion';
+import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
+import MuiAccordionDetails from '@material-ui/core/AccordionDetails';
 import MuiExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import { CustomThemeProps } from '../../../typings/CustomThemeProps';
@@ -11,15 +11,15 @@ type AccordionStyledProps = {
   theme: CustomThemeProps;
 };
 
-export const ExpansionPanel = styled(MuiExpansionPanel)`
-  &.MuiExpansionPanel-root {
+export const Accordion = styled(MuiAccordion)`
+  &.MuiAccordion-root {
     &::before {
       background-color: ${({ theme }: AccordionStyledProps) =>
         theme?.colors?.neutral?.lightest};
     }
 
     &:first-of-type {
-      .MuiExpansionPanelSummary-content {
+      .MuiAccordionSummary-content {
         margin: 20px 0;
 
         &.Mui-expanded {
@@ -40,15 +40,15 @@ export const ExpansionPanel = styled(MuiExpansionPanel)`
         opacity: 1;
       }
 
-      + .MuiExpansionPanel-root::before {
+      + .MuiAccordion-root::before {
         display: block;
       }
     }
   }
 `;
 
-export const ExpansionPanelSummary = styled(MuiExpansionPanelSummary)`
-  &.MuiExpansionPanelSummary-root {
+export const AccordionSummary = styled(MuiAccordionSummary)`
+  &.MuiAccordionSummary-root {
     align-items: flex-end;
     padding: 0;
 
@@ -57,7 +57,7 @@ export const ExpansionPanelSummary = styled(MuiExpansionPanelSummary)`
     }
   }
 
-  .MuiExpansionPanelSummary-content {
+  .MuiAccordionSummary-content {
     margin: 40px 0 20px 0;
 
     &.Mui-expanded {
@@ -66,8 +66,8 @@ export const ExpansionPanelSummary = styled(MuiExpansionPanelSummary)`
   }
 `;
 
-export const ExpansionPanelDetails = styled(MuiExpansionPanelDetails)`
-  &.MuiExpansionPanelDetails-root {
+export const AccordionDetails = styled(MuiAccordionDetails)`
+  &.MuiAccordionDetails-root {
     padding-left: 0;
     padding-right: 0;
   }

--- a/libs/ui/src/lib/navigation/Accordion/Accordion.tsx
+++ b/libs/ui/src/lib/navigation/Accordion/Accordion.tsx
@@ -24,20 +24,20 @@ export const Accordion = ({
   const handleChange = () => setExpanded(!expanded);
 
   return (
-    <Styled.ExpansionPanel
+    <Styled.Accordion
       className="testePanel"
       expanded={expanded}
       onChange={handleChange}
     >
-      <Styled.ExpansionPanelSummary
+      <Styled.AccordionSummary
         expandIcon={<Styled.ExpandMoreIcon />}
         aria-controls="panel1a-content"
         id="panel1a-header"
       >
         {summary}
-      </Styled.ExpansionPanelSummary>
-      <Styled.ExpansionPanelDetails>{children}</Styled.ExpansionPanelDetails>
-    </Styled.ExpansionPanel>
+      </Styled.AccordionSummary>
+      <Styled.AccordionDetails>{children}</Styled.AccordionDetails>
+    </Styled.Accordion>
   );
 };
 

--- a/libs/ui/src/lib/navigation/Accordion/__snapshots__/Accordion.spec.tsx.snap
+++ b/libs/ui/src/lib/navigation/Accordion/__snapshots__/Accordion.spec.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`Text Component renders connect theme correctly 1`] = `
 <div
-  className="MuiPaper-root MuiExpansionPanel-root testePanel css-tgd5hx Mui-expanded MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
+  className="MuiPaper-root MuiAccordion-root testePanel css-19f2gti Mui-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
     aria-controls="panel1a-content"
     aria-disabled={false}
     aria-expanded={true}
-    className="MuiButtonBase-root MuiExpansionPanelSummary-root css-16kqoxr Mui-expanded"
+    className="MuiButtonBase-root MuiAccordionSummary-root css-16uzaqg Mui-expanded"
     id="panel1a-header"
     onBlur={[Function]}
     onClick={[Function]}
@@ -26,7 +26,7 @@ exports[`Text Component renders connect theme correctly 1`] = `
     tabIndex={0}
   >
     <div
-      className="MuiExpansionPanelSummary-content Mui-expanded"
+      className="MuiAccordionSummary-content Mui-expanded"
     >
       <span>
         Lorem Ipsum
@@ -35,7 +35,7 @@ exports[`Text Component renders connect theme correctly 1`] = `
     <div
       aria-disabled={false}
       aria-hidden={true}
-      className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon Mui-expanded MuiIconButton-edgeEnd"
+      className="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon Mui-expanded MuiIconButton-edgeEnd"
       onBlur={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
@@ -89,7 +89,7 @@ exports[`Text Component renders connect theme correctly 1`] = `
           role="region"
         >
           <div
-            className="MuiExpansionPanelDetails-root css-1d3fmc1"
+            className="MuiAccordionDetails-root css-12ely3a"
           >
             <span>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum commodo.
@@ -104,13 +104,13 @@ exports[`Text Component renders connect theme correctly 1`] = `
 
 exports[`Text Component renders correctly 1`] = `
 <div
-  className="MuiPaper-root MuiExpansionPanel-root testePanel css-192dlty Mui-expanded MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
+  className="MuiPaper-root MuiAccordion-root testePanel css-123qacc Mui-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
     aria-controls="panel1a-content"
     aria-disabled={false}
     aria-expanded={true}
-    className="MuiButtonBase-root MuiExpansionPanelSummary-root css-16kqoxr Mui-expanded"
+    className="MuiButtonBase-root MuiAccordionSummary-root css-16uzaqg Mui-expanded"
     id="panel1a-header"
     onBlur={[Function]}
     onClick={[Function]}
@@ -128,7 +128,7 @@ exports[`Text Component renders correctly 1`] = `
     tabIndex={0}
   >
     <div
-      className="MuiExpansionPanelSummary-content Mui-expanded"
+      className="MuiAccordionSummary-content Mui-expanded"
     >
       <span>
         Lorem Ipsum
@@ -137,7 +137,7 @@ exports[`Text Component renders correctly 1`] = `
     <div
       aria-disabled={false}
       aria-hidden={true}
-      className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon Mui-expanded MuiIconButton-edgeEnd"
+      className="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon Mui-expanded MuiIconButton-edgeEnd"
       onBlur={[Function]}
       onDragLeave={[Function]}
       onFocus={[Function]}
@@ -188,7 +188,7 @@ exports[`Text Component renders correctly 1`] = `
           role="region"
         >
           <div
-            className="MuiExpansionPanelDetails-root css-1d3fmc1"
+            className="MuiAccordionDetails-root css-12ely3a"
           >
             <span
               data-testid="text-accordion"


### PR DESCRIPTION
**Onde encontrar mais informações sobre essa tarefa:**

- <a href="https://guiabolso.atlassian.net/browse/GBCN-1083" target="_BLANK">Link dessa tarefa no Jira</a>

**Esse PR é do tipo:**

- [ ] feature
- [x] bug
- [ ] chore

**O que estava acontecendo? Qual era o problema? Qual a necessidade?**

A corzinha no hover dos checkboxes estava errada. No Connect, onde a cor principal é azul, estava mostrando um fundinho rosa.
> _Disclaimer: que bugzinho d*sgraçado, eu quase não enxerguei onde tava o problema!!!!_

---
:warning: Edit: quando eu abri a PR, os testes falharam pois o MaterialUI renomeou o componente `ExpansionPanel` para `Accordion` (https://github.com/mui-org/material-ui/releases/tag/v4.11.0). Acabei fazendo essa atualização nessa PR também.