### PR TITLE
feat: 🎸 add helper to ab test

### DIFF
--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -7,5 +7,6 @@ export * from './lib/object/merge-right/merge-right';
 export * from './lib/scales/px-to-rem/px-to-rem';
 export * from './lib/scales/hex-to-rgb/hex-to-rgb';
 
+export * from './lib/ab-test/ab-test';
 export * from './lib/copy-to-clipboard/copy-to-clipboard';
 export * from './lib/create-id/create-id';

--- a/libs/utils/src/lib/ab-test/ab-test.spec.ts
+++ b/libs/utils/src/lib/ab-test/ab-test.spec.ts
@@ -1,0 +1,23 @@
+import { setABTest, getABTestValue, getAllABTestValues } from './ab-test';
+
+describe('A/B Test', () => {
+  setABTest('test1', 'first test');
+  setABTest('test2', 'second test');
+
+  const test1 = getABTestValue('test1');
+  const test2 = getABTestValue('ab-test-test2');
+
+  it('Should set a new item', () => {
+    expect(test1).toBe('first test');
+  });
+
+  it('Should get with prefix', () => {
+    expect(test2).toBe('second test');
+  });
+
+  it('Should get all in a array of object', () => {
+    const tests = getAllABTestValues();
+
+    expect(tests).toHaveLength(2);
+  });
+});

--- a/libs/utils/src/lib/ab-test/ab-test.ts
+++ b/libs/utils/src/lib/ab-test/ab-test.ts
@@ -1,0 +1,30 @@
+export const setABTest = (name: string, value: string) => {
+  if (!window || !window.localStorage) return;
+
+  return localStorage.setItem(`ab-test-${name}`, value);
+};
+
+export const getABTestValue = (name: string) => {
+  if (!window || !window.localStorage) return;
+
+  return localStorage.getItem(`ab-test-${name}`) || localStorage.getItem(name);
+};
+
+export const getAllABTestValues = ():
+  | []
+  | { name: string; value: string }[] => {
+  if (!window || !window.localStorage) return;
+
+  const tests = [];
+
+  for (const key in localStorage) {
+    if (key.indexOf('ab-test') !== -1) {
+      tests.push({
+        name: key,
+        value: localStorage.getItem(key),
+      });
+    }
+  }
+
+  return tests;
+};


### PR DESCRIPTION
**Onde encontrar mais informações sobre essa tarefa:**

- <a href="https://guiabolso.atlassian.net/browse/GBCONNECT-321" target="_BLANK">Link dessa tarefa no Jira</a>

**Esse PR é do tipo:**

- [x] feature
- [ ] bug
- [ ] chore

Adicionei um helper que padroniza os nomes dos itens adicionados no local storage com finalidade para teste a/b. Nesse helper também é possível recuperar um teste ou todos os testes ativos com os seus valores.