### PR TITLE
feat: onOpen props

### DIFF
--- a/libs/ui/src/lib/display/Tooltip/Tooltip.tsx
+++ b/libs/ui/src/lib/display/Tooltip/Tooltip.tsx
@@ -9,19 +9,21 @@ export type TooltipProps = {
   content: string | React.ReactNode | React.ReactNode[];
   children: React.ReactElement;
   title?: string | React.ReactNode | React.ReactNode[];
+  onOpen?: () => void;
 };
 
 const PopperComponent = props => {
   return <S.Popper {...props} />;
 };
 
-const Tooltip = ({ title, content, children }: TooltipProps) => (
+const Tooltip = ({ title, content, children, onOpen }: TooltipProps) => (
   <MuiTooltip
     arrow
     enterTouchDelay={1}
     leaveTouchDelay={1}
     interactive
     PopperComponent={PopperComponent}
+    onOpen={onOpen}
     title={
       <>
         {title && <S.Title variant="heading-06">{title}</S.Title>}


### PR DESCRIPTION
**Onde encontrar mais informações sobre essa tarefa:**

- <a href="LINK_DA_TASK_NO_JIRA_AQUI" target="_BLANK">Link dessa tarefa no Jira</a>

**Esse PR é do tipo:**

- [x] feature
- [ ] bug
- [ ] chore

**O que estava acontecendo? Qual era o problema? Qual a necessidade?**

<!-- Descrição do problema. -->

Precisamos que seja chamado um evento ao abrir a tooltip, mas atualmente o componente não possui suporte para isso.

**Como foi resolvido? O que você fez no código?**

<!-- Aqui podemos falar sobre a solução de forma geral e também da lógica na sequência de commits, para facilitar a leitura do código por parte do revisor. -->

Foi adicionado uma prop chamada `onOpen` que é análoga a existente no MUI.

