### PR TITLE
Adicionando lib de acesso ao storage

### DIFF
--- a/libs/utils/src/lib/ab-test/ab-test.ts
+++ b/libs/utils/src/lib/ab-test/ab-test.ts
@@ -7,14 +7,13 @@ export const setABTest = (
   value: string,
   storage: 'localStorage' | 'sessionStorage' = 'localStorage',
 ) => {
+  const key = `ab-test-${name}`;
   if (storage === 'sessionStorage') {
-    const key = `ab-test-${name}`;
     sessionKeys.push(key);
 
     return session.setItem(key, value);
   }
 
-  const key = `ab-test-${name}`;
   localKeys.push(key);
 
   return local.setItem(key, value);

--- a/libs/utils/src/lib/ab-test/ab-test.ts
+++ b/libs/utils/src/lib/ab-test/ab-test.ts
@@ -1,52 +1,37 @@
+import { local, session } from '../storage';
+const sessionKeys = [];
+const localKeys = [];
+
 export const setABTest = (
   name: string,
   value: string,
   storage: 'localStorage' | 'sessionStorage' = 'localStorage',
 ) => {
-  if (!window || !window.localStorage || !window.sessionStorage) return;
-
   if (storage === 'sessionStorage') {
-    return sessionStorage.setItem(`ab-test-${name}`, value);
+    const key = `ab-test-${name}`;
+    sessionKeys.push(key);
+
+    return session.setItem(key, value);
   }
 
-  return localStorage.setItem(`ab-test-${name}`, value);
+  const key = `ab-test-${name}`;
+  localKeys.push(key);
+
+  return local.setItem(key, value);
 };
 
 export const getABTestValue = (name: string) => {
-  if (!window || !window.localStorage || !window.sessionStorage) return;
-
   return (
-    localStorage.getItem(`ab-test-${name}`) ||
-    localStorage.getItem(name) ||
-    sessionStorage.getItem(`ab-test-${name}`) ||
-    sessionStorage.getItem(name)
+    local.getItem(`ab-test-${name}`) ||
+    local.getItem(name) ||
+    session.getItem(`ab-test-${name}`) ||
+    session.getItem(name)
   );
 };
 
 export const getAllABTestValues = ():
   | []
-  | { name: string; value: string }[] => {
-  if (!window || !window.localStorage || !window.sessionStorage) return;
-
-  const tests = [];
-
-  for (const key in localStorage) {
-    if (key.indexOf('ab-test') !== -1) {
-      tests.push({
-        name: key,
-        value: localStorage.getItem(key),
-      });
-    }
-  }
-
-  for (const key in sessionStorage) {
-    if (key.indexOf('ab-test') !== -1) {
-      tests.push({
-        name: key,
-        value: sessionStorage.getItem(key),
-      });
-    }
-  }
-
-  return tests;
-};
+  | { name: string; value: string }[] => [
+  ...sessionKeys.map(session.getItem),
+  ...localKeys.map(local.getItem),
+];

--- a/libs/utils/src/lib/storage/index.ts
+++ b/libs/utils/src/lib/storage/index.ts
@@ -1,0 +1,1 @@
+export { local, memory, session } from './storage';

--- a/libs/utils/src/lib/storage/storage.spec.ts
+++ b/libs/utils/src/lib/storage/storage.spec.ts
@@ -1,0 +1,121 @@
+import { createStorage } from './storage';
+
+describe('storage', () => {
+  const key = 'my-key';
+  const obj = { a: 1 };
+  const objString = JSON.stringify(obj);
+  const num = 123;
+  const numStr = String(num);
+
+  const store = {};
+  const StorageMock = () => {
+    return {
+      getItem: _key => store[_key],
+      setItem: (_key, value) => {
+        store[_key] = value.toString();
+      },
+      removeItem: _key => delete store[_key],
+      store,
+    };
+  };
+
+  const _memoryStorage = StorageMock();
+  Object.defineProperty(window, 'memoryStorage', {
+    value: _memoryStorage,
+  });
+
+  describe('localStorage', () => {
+    const _localStorage = StorageMock();
+    Object.defineProperty(window, 'localStorage', {
+      value: _localStorage,
+    });
+
+    const local = createStorage('local');
+
+    it('should be set item', () => {
+      local.setItem(key, obj);
+
+      expect(store[key]).toBe(objString);
+    });
+
+    it('should be get item', () => {
+      expect(store[key]).toBe(objString);
+      expect(local.getItem(key)).toEqual(obj);
+    });
+
+    it('should be remove item', () => {
+      local.removeItem(key);
+      expect(store[key]).toBe(undefined);
+      expect(local.getItem(key)).toBe('');
+    });
+  });
+
+  describe('sessionStorage', () => {
+    const _sessionStorage = StorageMock();
+    Object.defineProperty(window, 'sessionStorage', {
+      value: _sessionStorage,
+    });
+
+    const session = createStorage('session');
+
+    it('should be set item', () => {
+      session.setItem(key, num);
+
+      expect(store[key]).toBe(numStr);
+    });
+
+    it('should be get item', () => {
+      expect(store[key]).toBe(numStr);
+      expect(session.getItem(key)).toEqual(numStr);
+    });
+
+    it('should be remove item', () => {
+      session.removeItem(key);
+      expect(store[key]).toBe(undefined);
+      expect(session.getItem(key)).toBe('');
+    });
+  });
+
+  describe('memory', () => {
+    const memory = createStorage('memory');
+
+    it('should be set item', () => {
+      memory.setItem(key, num);
+
+      expect(memory.getItem(key)).toBe(numStr);
+    });
+
+    it('should be get item', () => {
+      expect(memory.getItem(key)).toEqual(numStr);
+    });
+
+    it('should be remove item', () => {
+      memory.removeItem(key);
+      expect(memory.getItem(key)).toBe('');
+    });
+  });
+
+  describe('should be set fallback memory', () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: undefined,
+    });
+
+    Object.defineProperty(window, 'sessionStorage', {
+      value: undefined,
+    });
+
+    it('should be set item', () => {
+      const local = createStorage('local');
+      const session = createStorage('session');
+      const unknow = createStorage('unknow' as 'session');
+
+      local.setItem(key, num);
+      session.setItem(key, num);
+      unknow.setItem(key, num);
+
+      expect(local.getItem(key)).toBe(numStr);
+      expect(session.getItem(key)).toBe(numStr);
+      expect(unknow.getItem(key)).toBe(numStr);
+    });
+  });
+});

--- a/libs/utils/src/lib/storage/storage.ts
+++ b/libs/utils/src/lib/storage/storage.ts
@@ -1,0 +1,84 @@
+function StorageImpl(instance: any) {
+  const setItem = <T, K extends string>(key: K, value: T) => {
+    try {
+      const _value =
+        typeof value === 'object' && value !== null && value !== undefined
+          ? JSON.stringify(value)
+          : String(value);
+
+      instance.setItem(key, _value);
+
+      return true;
+    } catch (error) {
+      // TODO: Add new relic
+    }
+  };
+
+  const removeItem = <T extends string>(key: T) => {
+    try {
+      instance.removeItem(key);
+
+      return true;
+    } catch (error) {
+      // TODO: Add new relic
+    }
+  };
+
+  const getItem = <T extends string>(key: T) => {
+    try {
+      const value = instance.getItem(key) || '';
+      const local = value.match(/\[|\{/) ? JSON.parse(value) : value;
+
+      return local;
+    } catch (error) {
+      // TODO: Add new relic
+    }
+  };
+
+  return {
+    getItem,
+    removeItem,
+    setItem,
+  };
+}
+
+const Db = new Map();
+
+const memoryStorage = {
+  getItem: (key: string) => Db.get(key),
+  removeItem: (key: string) => Db.delete(key),
+  setItem: (key: string, value: unknown) => Db.set(key, String(value)),
+};
+
+declare global {
+  interface Window {
+    memoryStorage: typeof memoryStorage;
+  }
+}
+// @ts-ignore
+window.__proto__.memoryStorage = memoryStorage;
+
+type StorageTypes = 'local' | 'session' | 'memory';
+
+export function createStorage(type: StorageTypes) {
+  let $Storage = undefined;
+
+  try {
+    $Storage =
+      ({
+        local: window.localStorage,
+        session: window.sessionStorage,
+        memory: window.memoryStorage,
+      } as { [K in StorageTypes]: unknown })[type] ?? window.memoryStorage;
+  } catch (error) {
+    $Storage = window.memoryStorage;
+  }
+
+  return StorageImpl($Storage);
+}
+
+export const local = createStorage('local');
+
+export const session = createStorage('session');
+
+export const memory = createStorage('memory');


### PR DESCRIPTION
**Descrição**

Todo IO tanto tcp (http e ws), storage, uri, inputs e etc devem ser tratados. Nessa PR estamos introduzindo a lib de storage que visa tratar o acesso ao localStorage e o acesso ao sessionStorage.

Quando o usuário não dá permissão ao acesso ao storage, tanto no browser, quanto para acesso via celular ou webview, estes recursos ficam indisponíveis para nós desenvolvedoreas. E se não, ocasiona uma boa e velha tela em branco.

![image](https://user-images.githubusercontent.com/11713190/120230943-bbc92700-c226-11eb-8ac2-6144fa76f541.png)


**O que foi feito**

- adicionado lib storage, para localStorage, memory e sessionStorage
- refatorado ab-test para usar lib storage